### PR TITLE
Add scope to initially reissued token

### DIFF
--- a/authorizer/app.py
+++ b/authorizer/app.py
@@ -55,8 +55,6 @@ def authnz_token():  # type: ignore
     :query capability: One or more capabilities to check
     :query satisfy: satisfy ``all`` (default) or ``any`` of the
      capability checks.
-    :query reissue_token: If ``true``, then reissue token before
-     setting the user headers.
     :<header Authorization: The JWT token. This must always be the
      full JWT token. The token should be in this  header as
      type ``Bearer``, but it may be type ``Basic`` if ``x-oauth-basic``
@@ -75,7 +73,7 @@ def authnz_token():  # type: ignore
      in the ``isMemberOf`` claim, the names of the groups will be
      returned, comma-separated, in this header.
     :>header X-Auth-Request-Token: If enabled, the encoded token will
-     be set. If ``reissue_token`` is true, the token is reissued first
+     be set.
     :>header X-Auth-Request-Token-Ticket: When a ticket is available
      for the token, we will return it under this header.
     :>header X-Auth-Request-Token-Capabilities: If the token has
@@ -270,12 +268,7 @@ def _make_success_headers(
             groups = ",".join([g["name"] for g in groups_list])
             response.headers["X-Auth-Request-Groups"] = groups
 
-    ticket_prefix = current_app.config["OAUTH2_STORE_SESSION"]["TICKET_PREFIX"]
-    original_auth = _find_token(ORIGINAL_TOKEN_HEADER) or ""
-    oauth2_proxy_ticket = original_auth if original_auth.startswith(f"{ticket_prefix}:") else ""
-    reissue_requested = request.args.get("reissue_token", "").lower() == "true"
-    if reissue_requested:
-        encoded_token, oauth2_proxy_ticket = _check_reissue_token(encoded_token, verified_token)
+    encoded_token, oauth2_proxy_ticket = _check_reissue_token(encoded_token, verified_token)
     response.headers["X-Auth-Request-Token"] = encoded_token
     response.headers["X-Auth-Request-Token-Ticket"] = oauth2_proxy_ticket
 

--- a/authorizer/app.py
+++ b/authorizer/app.py
@@ -308,8 +308,10 @@ def _check_reissue_token(encoded_token: str, decoded_token: Mapping[str, Any]) -
     oauth2_proxy_ticket_str = _ticket_str_from_cookie(oauth2_proxy_cookie_val)
     ticket = None
     new_audience = None
-
     if not from_this_issuer:
+        # Make a copy of the previous token and add capabilities
+        decoded_token = dict(decoded_token)
+        decoded_token["scope"] = capabilities_from_groups(decoded_token)
         new_audience = current_app.config.get("OAUTH2_JWT.AUD.DEFAULT", "")
         ticket = parse_ticket(cookie_name, oauth2_proxy_ticket_str)
         # If we didn't issue it, it came from a provider, and it is

--- a/authorizer/app.py
+++ b/authorizer/app.py
@@ -304,7 +304,7 @@ def _check_reissue_token(encoded_token: str, decoded_token: Mapping[str, Any]) -
     if not from_this_issuer:
         # Make a copy of the previous token and add capabilities
         decoded_token = dict(decoded_token)
-        decoded_token["scope"] = capabilities_from_groups(decoded_token)
+        decoded_token["scope"] = " ".join(capabilities_from_groups(decoded_token))
         new_audience = current_app.config.get("OAUTH2_JWT.AUD.DEFAULT", "")
         ticket = parse_ticket(cookie_name, oauth2_proxy_ticket_str)
         # If we didn't issue it, it came from a provider, and it is

--- a/kube/template/init.sh
+++ b/kube/template/init.sh
@@ -29,7 +29,7 @@ echo "Generating Issuer Keypair... private.pem, public.pem"
 openssl genrsa -out private.pem 2048 2> /dev/null
 openssl rsa -in private.pem -outform PEM -pubout -out public.pem
 modulus_hex=$(openssl rsa -pubin -inform PEM -modulus -noout -in public.pem | sed 's/Modulus=//')
-modulus_urlsafe_b64=$(printf -- "$modulus_hex" | xxd -r -p | $b64 | sed 's/+/-/g;s/\//_/g')
+modulus_urlsafe_b64=$(printf -- "$modulus_hex" | xxd -r -p | $b64 | sed 's/+/-/g;s/\//_/g;s/=//g')
 
 ISSUER_PRIVATE_KEY=$(cat private.pem)
 ISSUER_PRIVATE_KEY_INDENT_10=$(printf -- "$ISSUER_PRIVATE_KEY" | sed 's/^/          /')


### PR DESCRIPTION
This PR adds the scope when we reissue the token from CILogon. It also removes the need for the `reissue_token` URL argument and a small fix for the jwks.json file