### PR TITLE
[DM-23646] Fix get_unverified_header call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Change log
 ##########
 
+0.2.1 (2020-03-18)
+==================
+
+- Fix misplaced parameter when decoding tokens in the ``/auth`` route.
+
 0.2.0 (2020-03-16)
 ==================
 

--- a/src/jwt_authorizer/authnz.py
+++ b/src/jwt_authorizer/authnz.py
@@ -42,10 +42,10 @@ def authenticate(encoded_token: str) -> Mapping[str, Any]:
     :raises PyJWTError: if there's an issue decoding the token
     :raises Exception: if there's some other issue
     """
-    unverified_token = jwt.decode(encoded_token, verify=False)
-    unverified_headers = jwt.get_unverified_header(
-        encoded_token, algorithms=ALGORITHM
+    unverified_token = jwt.decode(
+        encoded_token, algorithms=ALGORITHM, verify=False
     )
+    unverified_headers = jwt.get_unverified_header(encoded_token)
     jti = unverified_token.get("jti", "UNKNOWN")
     logger.debug(f"Authenticating token with jti: {jti}")
     if current_app.config["NO_VERIFY"] is True:

--- a/tests/authnz_test.py
+++ b/tests/authnz_test.py
@@ -4,12 +4,57 @@ from __future__ import annotations
 
 import copy
 from typing import TYPE_CHECKING
+from unittest.mock import call, patch
 
-from jwt_authorizer.authnz import capabilities_from_groups
-from tests.util import create_test_app
+import jwt
+
+from jwt_authorizer.authnz import authenticate, capabilities_from_groups
+from jwt_authorizer.tokens import ALGORITHM
+from tests.util import RSAKeyPair, create_test_app
 
 if TYPE_CHECKING:
     from typing import Any, Dict
+
+
+def test_authenticate() -> None:
+    payload = {
+        "aud": "https://test.example.com/",
+        "email": "some-user@example.com",
+        "iss": "https://orig.example.com/",
+        "jti": "some-unique-id",
+        "sub": "some-user",
+        "uidNumber": "1000",
+    }
+    keypair = RSAKeyPair()
+    app = create_test_app(
+        ISSUERS={
+            "https://orig.example.com/": {
+                "audience": "https://test.example.com/",
+                "issuer_key_ids": ["some-kid"],
+            },
+        },
+        OAUTH2_STORE_SESSION={"TICKET_PREFIX": "oauth2_proxy"},
+    )
+
+    # Generate a valid token.
+    token = jwt.encode(
+        payload,
+        keypair.private_key_as_pem(),
+        algorithm=ALGORITHM,
+        headers={"kid": "some-kid"},
+    )
+
+    # Analyze it, patching out the call to retrieve the public key from a
+    # remote web site (but making sure that it was called correctly).
+    with app.app_context():
+        with patch("jwt_authorizer.authnz.get_key_as_pem") as get_key_as_pem:
+            get_key_as_pem.return_value = keypair.public_key_as_pem()
+            result = authenticate(token.decode())
+            assert get_key_as_pem.call_args_list == [
+                call("https://orig.example.com/", "some-kid")
+            ]
+
+    assert result == payload
 
 
 def test_capabilities_from_groups() -> None:


### PR DESCRIPTION
A stray alogorithms parameter was added to the get_unverified_header
call instead of, as intended, jwt.decode.  Move it to the correct
call.