### PR TITLE
[DM-23646] Fix session date parsing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Change log
 ##########
 
+0.2.2 (2020-03-19)
+==================
+
+- Fix decoding of dates in the ``oauth2_proxy`` session.
+
 0.2.1 (2020-03-18)
 ==================
 

--- a/src/jwt_authorizer/tokens.py
+++ b/src/jwt_authorizer/tokens.py
@@ -27,6 +27,7 @@ import hmac
 import json
 import logging
 import os
+import re
 import struct
 from binascii import Error
 from calendar import timegm
@@ -574,6 +575,15 @@ class TokenStore:
 
     @staticmethod
     def _parse_session_date(date_str: str) -> datetime:
+        """Parse a date from a session record.
+
+        This date may be written by oauth2_proxy instead of us, in which case
+        it will use a Go date format that includes fractional seconds down to
+        the nanosecond.  Python doesn't have a date format that parses this,
+        so the fractional seconds portion will be dropped, leading to an
+        inaccuracy of up to a second.
+        """
+        date_str = re.sub("[.][0-9]+Z$", "Z", date_str)
         date = datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%SZ")
         return date.replace(tzinfo=timezone.utc)
 

--- a/tests/analyze_test.py
+++ b/tests/analyze_test.py
@@ -11,7 +11,7 @@ from unittest.mock import ANY, call, patch
 import fakeredis
 import jwt
 
-from jwt_authorizer.tokens import ALGORITHM, Ticket, issue_token
+from jwt_authorizer.tokens import ALGORITHM, Ticket, TokenStore, issue_token
 from tests.util import RSAKeyPair, create_test_app
 
 
@@ -166,3 +166,9 @@ def test_analyze_token() -> None:
             "valid": True,
         },
     }
+
+
+def test_parse_session_date() -> None:
+    """Check that we can parse the session dates written by oauth2_proxy."""
+    date = TokenStore._parse_session_date("2020-03-18T02:28:20.559385848Z")
+    assert date.strftime("%Y-%m-%d %H:%M:%S %z") == "2020-03-18 02:28:20 +0000"


### PR DESCRIPTION
oauth2_proxy writes out a session date with nanoseconds, which
Python strptime doesn't know how to parse.  Patch around it with
a regex for now.